### PR TITLE
Fix Veg Badge Styling in Top Notch Dishes Section

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -107,9 +107,16 @@ const Index = () => {
               <Card key={dish.id} className="card-royal group hover:scale-105 transition-transform">
                 <CardHeader className="relative">
                   <div className="flex justify-between items-start">
-                    <Badge variant={dish.is_veg ? "secondary" : "destructive"} className="mb-2">
+                    <Badge
+                      className={`mb-2 ${
+                        dish.is_veg
+                          ? "bg-green-500/20 text-green-600 border border-green-500"
+                          : "bg-red-500/20 text-red-600 border border-red-500"
+                      }`}
+                    >
                       {dish.is_veg ? "Veg" : "Non-Veg"}
                     </Badge>
+
                     <div className="flex items-center space-x-1">
                       <Star className="h-4 w-4 fill-royal-gold text-royal-gold" />
                       <span className="font-semibold">{dish.rating}</span>


### PR DESCRIPTION
**Description:**
This PR resolves #11 
by adding a green background, text, and border styling to Veg badges in the Top Notch Dishes section for consistent visual distinction with Non-Veg badges.

**Changes Made:**

1.Removed reliance on variant="secondary" for Veg badge styling.
2.Added Tailwind classes to set:
3.Light green background (bg-green-500/20)
4.Green text (text-green-600)
5.Green border (border-green-500)
6.Maintained consistent red styling for Non-Veg badges.

**Before:**
- Veg badges displayed with default gray styling.
- Non-Veg badges had correct red background.

**After:**
-Veg badges now have a green background with matching text and border.
-Consistent color coding between Veg and Non-Veg options.

**Screenshot:**
 Before------
<img width="1851" height="593" alt="Screenshot (162)" src="https://github.com/user-attachments/assets/b7806463-bd2d-41f3-9e19-270caa78b2d4" />
 After------
<img width="1873" height="741" alt="Screenshot (163)" src="https://github.com/user-attachments/assets/775b8b4e-f299-4dda-9c22-127aa94f328f" />
--
