### PR TITLE
Add Clear Filters Button on Menu Page

### DIFF
--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +23,16 @@ const Menu = () => {
       return data;
     }
   });
+
+  // Reset all filters
+  const clearFilters = () => {
+    setSearchQuery("");
+    setCategoryFilter("");
+    setVegFilter(null);
+  };
+
+  // Check if any filters are applied
+  const hasFilters = searchQuery !== "" || categoryFilter !== "" || vegFilter !== null;
 
   if (isLoading) {
     return (
@@ -72,13 +81,24 @@ const Menu = () => {
 
       {/* Search and Filters */}
       <section className="px-4 mb-8">
-        <div className="container mx-auto">
+        <div className="container mx-auto flex flex-col sm:flex-row gap-4 items-center">
           <MenuSearch
             onSearch={setSearchQuery}
             onCategoryFilter={setCategoryFilter}
             onVegFilter={setVegFilter}
             categories={categories}
           />
+          <button
+            onClick={clearFilters}
+            disabled={!hasFilters}
+            className={`px-4 py-2 rounded-md font-semibold text-sm transition-colors ${
+              hasFilters
+                ? 'bg-royal-gold text-black hover:bg-royal-gold/80'
+                : 'bg-gray-500 text-gray-300 cursor-not-allowed'
+            }`}
+          >
+            Clear Filters
+          </button>
         </div>
       </section>
 


### PR DESCRIPTION
Fixes #75

Added a "Clear Filters" button to the Menu page to reset search query, category, and veg/non-veg filters. Tested locally to ensure functionality and responsiveness.

Changes:
- Added clearFilters function to reset filter states
- Added button with Tailwind styling in the filter section
- Implemented logic to disable button when no filters are active
- Ensured responsive layout with flexbox

Screenshot:
<img width="1688" height="456" alt="image" src="https://github.com/user-attachments/assets/a9068997-3890-4d95-a94d-0f46de72f75c" />


Please review it and tell me if any changes are needed.
Thankyou!
