### PR TITLE
Add Show More Button for Long Menu Categories

### DIFF
--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +23,16 @@ const Menu = () => {
       return data;
     }
   });
+
+  // Reset all filters
+  const clearFilters = () => {
+    setSearchQuery("");
+    setCategoryFilter("");
+    setVegFilter(null);
+  };
+
+  // Check if any filters are applied
+  const hasFilters = searchQuery !== "" || categoryFilter !== "" || vegFilter !== null;
 
   if (isLoading) {
     return (
@@ -72,13 +81,24 @@ const Menu = () => {
 
       {/* Search and Filters */}
       <section className="px-4 mb-8">
-        <div className="container mx-auto">
+        <div className="container mx-auto flex flex-col sm:flex-row gap-4 items-center">
           <MenuSearch
             onSearch={setSearchQuery}
             onCategoryFilter={setCategoryFilter}
             onVegFilter={setVegFilter}
             categories={categories}
           />
+          <button
+            onClick={clearFilters}
+            disabled={!hasFilters}
+            className={`px-4 py-2 rounded-md font-semibold text-sm transition-colors ${
+              hasFilters
+                ? 'bg-royal-gold text-black hover:bg-royal-gold/80'
+                : 'bg-gray-500 text-gray-300 cursor-not-allowed'
+            }`}
+          >
+            Clear Filters
+          </button>
         </div>
       </section>
 

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -10,6 +10,7 @@ const Menu = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [vegFilter, setVegFilter] = useState<boolean | null>(null);
+  const [expandedCategories, setExpandedCategories] = useState<string[]>([]);
 
   const { data: menuItems, isLoading } = useQuery({
     queryKey: ['menu-items'],
@@ -33,6 +34,15 @@ const Menu = () => {
 
   // Check if any filters are applied
   const hasFilters = searchQuery !== "" || categoryFilter !== "" || vegFilter !== null;
+
+  // Toggle expanded state for a category
+  const toggleCategory = (category: string) => {
+    setExpandedCategories(prev =>
+      prev.includes(category)
+        ? prev.filter(c => c !== category)
+        : [...prev, category]
+    );
+  };
 
   if (isLoading) {
     return (
@@ -93,8 +103,8 @@ const Menu = () => {
             disabled={!hasFilters}
             className={`px-4 py-2 rounded-md font-semibold text-sm transition-colors ${
               hasFilters
-                ? 'bg-royal-gold text-black hover:bg-royal-gold/80'
-                : 'bg-gray-500 text-gray-300 cursor-not-allowed'
+                ? 'bg-royal-gold text-black hover:bg-royal-gold/90'
+                : 'bg-muted text-muted-foreground cursor-not-allowed'
             }`}
           >
             Clear Filters
@@ -108,7 +118,7 @@ const Menu = () => {
           <div className="container mx-auto">
             <h2 className="font-playfair text-4xl font-bold text-royal-gold text-center mb-12">{category}</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {items.map((item: any) => (
+              {(expandedCategories.includes(category) ? items : items.slice(0, 6)).map((item: any) => (
                 <Card key={item.id} className="card-royal hover:scale-105 transition-transform">
                   <div className="relative">
                     <img 
@@ -173,6 +183,16 @@ const Menu = () => {
                 </Card>
               ))}
             </div>
+            {items.length > 6 && (
+              <div className="text-center mt-8">
+                <button
+                  onClick={() => toggleCategory(category)}
+                  className="px-4 py-2 rounded-md font-semibold text-sm bg-royal-gold text-black hover:bg-royal-gold/90 transition-colors"
+                >
+                  {expandedCategories.includes(category) ? 'Show Less' : 'Show More'}
+                </button>
+              </div>
+            )}
           </div>
         </section>
       ))}


### PR DESCRIPTION
Fixes #77

Added a "Show More" button for menu categories with more than 6 items to improve usability by limiting initial display. The button toggles to "Show Less" when expanded and is styled with Tailwind CSS to match the royal-gold theme. Tested locally to ensure compatibility with existing filters and responsiveness.

Changes:
- Added expandedCategories state to track expanded categories
- Modified category rendering to show 6 items unless expanded
- Added Show More/Show Less button for categories with >6 items
- Styled button with bg-royal-gold, text-black, hover:bg-royal-gold/90
- Ensured compatibility with Clear Filters button and existing filters

Screenshot:

<img width="1820" height="545" alt="Screenshot 2025-09-01 164442" src="https://github.com/user-attachments/assets/a0823434-58e9-40e1-829a-98c5e986691b" />


<img width="1858" height="661" alt="Screenshot 2025-09-01 164520" src="https://github.com/user-attachments/assets/e6c81d5b-df42-4500-9d20-854ad059f9cb" />

Please review and tell me if any changes are needed.

Thanks !